### PR TITLE
wrap sponsor link with explicit link

### DIFF
--- a/_posts/2016-10-07-updating-in-elm-town-episode-2.markdown
+++ b/_posts/2016-10-07-updating-in-elm-town-episode-2.markdown
@@ -7,7 +7,7 @@ Discussion about the writing and simplification of update functions
 
 ## Sponsors
 
-Humblespark - http://humblespark.com
+Humblespark - [https://humblespark.com](https://humblespark.com)
 
 ## Show Notes – Updating-In-Elm-Town-Ep-2
 


### PR DESCRIPTION
it seems the renderer doesn't do the github thing where it automatically detects urls and replaces them with `<a>`s
